### PR TITLE
gha: update terraform 0.12 version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,21 +11,21 @@ jobs:
       - name: 'Terraform Format'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'fmt'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Terraform Init'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'init'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Terraform Validate'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'validate'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       - name: 'Terraform Plan'
         uses: hashicorp/terraform-github-actions@master
         with:
-          tf_actions_version: 0.12.20
+          tf_actions_version: 0.12.29
           tf_actions_subcommand: 'plan'
           args: '-var-file="dev.tfvars"'
         env:


### PR DESCRIPTION
Update the Github action to use Terraform v0.12.19 for checks. 

Side note: Upgrading to v0.13.x is on the board.
