### PR TITLE
github: add codeowners, PR template and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, @bulderbank/cloud will be requested for review
+# when someone opens a pull request.
+* @bulderbank/cloud

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug concerning the Bulder infrastructure
+labels: bug
+
+---
+
+# 🐛 Bug Report
+<!--
+*A clear and concise description of what the bug is and how the expected behavior/code should be.*
+-->
+
+
+## How to reproduce the bug
+<!--
+*Here you can write in freetext how to reproduce the bug*
+-->
+
+
+## Additional context
+<!--
+*Here you can add any addition context, such as links to forums and issue trackers.
+Basically anything that can help debugging and fixing this bug report*
+-->
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: feature
+
+---
+
+# 👨‍🍳 Feature Request
+<!--
+*A clear and concise description of what you want to be added. Add any considered drawbacks.*
+-->
+
+
+## Alternatives you've considered
+<!--
+*A clear and concise description of any alternative solutions or features you've considered.*
+-->
+
+
+## Documentation, articles, links and others
+<!--
+*Here you can add documentation such as links and articles,
+maybe add some screenshots, sketches or a picture of whiteboard scribblings?*
+-->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+  Does this PR reference or resolve Issue?
+    Related: #000, #000
+    Resolves: #000, #000
+-->
+
+<!--
+  What was the motivation behind this change?
+-->
+
+
+
+### Documentation, links and more
+<!--
+  Here you can add documentation such as links and articles,
+  anything that was useful during the work on this PR.
+-->
+


### PR DESCRIPTION
<!--
  What was the motivation behind this change?
-->

Add CODEOWNERS file for requiring review from team-cloud, also add templates for PRs and issues.